### PR TITLE
Emphasize randomness importance for the blinding factor

### DIFF
--- a/draft-irtf-cfrg-rsa-blind-signatures.md
+++ b/draft-irtf-cfrg-rsa-blind-signatures.md
@@ -245,6 +245,16 @@ Steps:
 11. output blinded_msg, inv
 ~~~
 
+The blinding factor r must be randomly chosen from a uniform distribution.
+
+In order to do so, the random_integer_uniform function can be implemented by obtaining L uniform bytes, where
+
+~~~
+L = ceil((ceil(log2(n - m)) + k) / 8)
+~~~
+
+These uniform bytes are then interpreted as an integer via OS2IP, which is then reduced mod (n - m) and added to n. Choosing k >= 128 is recommended and gives bias at most 2^-k.
+
 ### BlindSign
 
 rsabssa_blind_sign performs the RSA private key operation on the client's

--- a/draft-irtf-cfrg-rsa-blind-signatures.md
+++ b/draft-irtf-cfrg-rsa-blind-signatures.md
@@ -246,14 +246,7 @@ Steps:
 ~~~
 
 The blinding factor r must be randomly chosen from a uniform distribution.
-
-In order to do so, the random_integer_uniform function can be implemented by obtaining L uniform bytes, where
-
-~~~
-L = ceil((ceil(log2(n - m)) + k) / 8)
-~~~
-
-These uniform bytes are then interpreted as an integer via OS2IP, which is then reduced mod (n - m) and added to n. Choosing k >= 128 is recommended and gives bias at most 2^-k.
+This is typically done via rejection sampling.
 
 ### BlindSign
 

--- a/poc/rsabssa.py
+++ b/poc/rsabssa.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 
-from Crypto.Util.number import inverse, ceil_div
+from Crypto.Util.number import size, inverse, ceil_div
 from Crypto.Hash import SHA384
 from Crypto.Util.strxor import strxor
 from Crypto.PublicKey import RSA
@@ -60,10 +60,18 @@ def RSAVP1(public_key: RsaKey, r: int) -> int:
 
 
 def random_integer_uniform(m: int, n: int) -> int:
-    range = n - m
-    L = ceil_div(ceil(log2(range)) + 128, 8)
-    randomBytes = urandom(L)
-    return m + OS2IP(randomBytes) % range
+    # Implement rejection sampling.
+    # This is for reference only; most cryptographic libraries include
+    # functions to generate random integers from a uniform distribution.
+    range = max - min
+    rangeBits = size(range - 1)
+    rangeLen = ceil_div(rangeBits, 8)
+    mask = (1 << rangeBits) - 1
+    while True:
+        randomBytes = urandom(rangeLen)
+        r = OS2IP(randomBytes) & mask
+        if r < range:
+            return min + r
 
 
 def rsabssa_blind(

--- a/poc/rsabssa.py
+++ b/poc/rsabssa.py
@@ -9,7 +9,6 @@ from Crypto.Signature import pss
 from Crypto.Signature.pss import MGF1
 
 from os import urandom
-from math import ceil, log2
 
 H = SHA384
 MgfHash = SHA384


### PR DESCRIPTION
- Add yet another emphasis on the fact that `r` must be chosen from a uniform distribution
- Suggest a way to implement `random_integer_uniform`, by generating and reducing a larger integer
- Update the Python code to do exactly that instead of rejection sampling (nothing wrong with rejection sampling, but the reduction method is shorter to document)

Fixes #55 