### PR TITLE
Draft blind signature nits

### DIFF
--- a/draft-irtf-cfrg-rsa-blind-signatures.md
+++ b/draft-irtf-cfrg-rsa-blind-signatures.md
@@ -395,8 +395,10 @@ An alternative solution to this problem of message blindness is to give signers 
 message being signed is well-structured. Depending on the application, zero knowledge proofs
 could be useful for this purpose. Defining such a proof is out of scope for this document.
 
-Verifiers should check that, in addition to the signature validity, the unblinded message is 
-well-structured.
+Verifiers should check that, in addition to signature validity, the unblinded message is 
+well-structured for the relevant application. For example, if an application of this protocol
+requires messages to be structures of a particular form, then verifiers should check that 
+unblinded messages adhere to this form.
 
 ## Randomized and Deterministic Signatures {#det-sigs}
 

--- a/draft-irtf-cfrg-rsa-blind-signatures.md
+++ b/draft-irtf-cfrg-rsa-blind-signatures.md
@@ -395,6 +395,9 @@ An alternative solution to this problem of message blindness is to give signers 
 message being signed is well-structured. Depending on the application, zero knowledge proofs
 could be useful for this purpose. Defining such a proof is out of scope for this document.
 
+Verifiers should check that, in addition to the signature validity, the unblinded message is 
+well-structured.
+
 ## Randomized and Deterministic Signatures {#det-sigs}
 
 When sLen > 0, the PSS salt is a randomly generated string chosen when a message is encoded.
@@ -418,7 +421,7 @@ RSA is well known to permit key substitution attacks, wherein an attacker genera
 (skA, pkA) that verify some known (message, signature) pair produced under a different (skS, pkS)
 key pair {{WM99}}. This means it may be possible for an attacker to use a (message, signature) pair
 from one context in another. Entities that verify signatures must take care to ensure a
-(message, signature) pair verifies with the expected public key.
+(message, signature) pair verifies with a valid public key from the expected issuer.
 
 ## Alternative RSA Encoding Functions
 


### PR DESCRIPTION
Looks great! Just small stuff.

I wanted to ensure we emphasize that verifiers check that an unblinded message is valid. This gets into the case where a client may be able to get a message signed, then create many valid tokens by generating new r's, and inverting on the fly. If the unblinded message is well structured, I do not believe this is possible. Without strong message structure this may be possible. I have never demonstrated it.

Also change wording on the key substitution section. I was initially confused by the intent here. Hopefully this helps clarify?