### PR TITLE
Add external interface to support salted messages

### DIFF
--- a/draft-irtf-cfrg-rsa-blind-signatures.md
+++ b/draft-irtf-cfrg-rsa-blind-signatures.md
@@ -62,6 +62,12 @@ informative:
       -
         ins: H. Krawczyk
         org: IBM Research, NY, USA
+  Lys22:
+    title: "Security Analysis of RSA-BSSA"
+    target: https://eprint.iacr.org/2022/895
+    authors:
+      -
+        ins: A. Lysyanskaya
   BLS-Proposal:
     title: "[Privacy-pass] External verifiability: a concrete proposal"
     target: https://mailarchive.ietf.org/arch/msg/privacy-pass/BDOOhSLwB3uUJcfBiss6nUF5sUA/
@@ -364,7 +370,8 @@ input to rsabssa_blindsign.
 
 Applications that provide high-entropy input messages can expose the internal
 rsabssa_blind and rsabssa_finalize directly, as the additional message randomization
-does not offer security advantages. See {{apis}} and {{message-entropy}} for more information.
+does not offer security advantages. See {{Lys22}}, {{apis}}, and {{message-entropy}}
+for more information.
 
 ### Salted Blind
 
@@ -556,7 +563,7 @@ unblinded messages adhere to this form.
 
 ## Message Entropy {#message-entropy}
 
-The choice of blinding mechanism has security implications on the blindness properties of the
+As discussed in {{Lys22}}, the choice of blinding mechanism has security implications on the blindness properties of the
 blind RSA protocol. In particular, a malicious signer can construct an invalid public and use
 it to learn information about low-entropy with input messages. Note that some invalid public
 keys may not yield valid signatures when run with the protocol, e.g., because the signature

--- a/draft-irtf-cfrg-rsa-blind-signatures.md
+++ b/draft-irtf-cfrg-rsa-blind-signatures.md
@@ -398,7 +398,7 @@ Errors:
 Steps:
 1. msg_salt = random(32)
 2. salted_msg = msg_salt || msg
-3. blinded_msg, inv = blind(pkS, msg)
+3. blinded_msg, inv = blind(pkS, salted_msg)
 4. output msg_salt, blinded_msg, inv
 ~~~
 

--- a/draft-irtf-cfrg-rsa-blind-signatures.md
+++ b/draft-irtf-cfrg-rsa-blind-signatures.md
@@ -362,7 +362,7 @@ the internal functions in {{generation}}. Note that this only changes what is pa
 to rsabssa_blind and rsabssa_finalize, as the application message is not provided as
 input to rsabssa_blindsign.
 
-Applciations that provide high-entropy input messages can expose the internal
+Applications that provide high-entropy input messages can expose the internal
 rsabssa_blind and rsabssa_finalize directly, as the additional message randomization
 does not offer security advantages. See {{apis}} and {{message-entropy}} for more information.
 

--- a/draft-irtf-cfrg-rsa-blind-signatures.md
+++ b/draft-irtf-cfrg-rsa-blind-signatures.md
@@ -466,7 +466,7 @@ Errors:
 - "invalid signature": Raised when the signature is invalid
 
 Steps:
-1. salted_msg = HF(salt_msg || msg )
+1. salted_msg = salt_msg || msg
 2. result = RSASSA-PSS-VERIFY(pkS, salted_msg, sig)
 3. If result = "valid signature", output "valid signature", else
   raise "invalid signature" and stop

--- a/draft-irtf-cfrg-rsa-blind-signatures.md
+++ b/draft-irtf-cfrg-rsa-blind-signatures.md
@@ -338,6 +338,117 @@ Steps:
    raise "invalid signature" and stop
 ~~~
 
+## External Application Interface
+
+In order to provably satisfy the blindness property against a malicious signer
+{{XXXX}}, it is important that the signed message is randomized prior to being
+sent to the signer. This section presents an interface for blinding, finalizing
+and verifying messages that have been randomized to produce a signature.
+TODO: Expand on this upon publication of {{ XXXX }}.
+
+Therefore, the message is salted with 32 random octets. Applciations that provide
+high-entropy inputs can expose the internal rsabssa_blind and rsabssa_finalize
+directly, as the additional message randomization does not offer security advantages.
+
+### Salted Blind
+
+rsabssa_salted_blind invokes rsabssa_blind with a salted input message and outputs the
+blinded message to be sent to the server and the corresponding inverse, both encoded
+as octet strings, as well as the fresh message salt, which is 32 random bytes.
+
+~~~
+rsabssa_salted_blind(pkS, msg)
+
+Parameters:
+- kLen, the length in octets of the RSA modulus n
+- kBits, the length in bits of the RSA modulus n
+- HF, the hash function used to hash the message
+- MGF, the mask generation function
+
+Inputs:
+- pkS, server public key (n, e)
+- msg, message to be signed, an octet string
+
+Outputs:
+- blinded_msg, an octet string of length kLen
+- inv, an octet string of length kLen
+- msg_salt, an octet string of length 32 bytes
+
+Errors:
+- "message too long": Raised when the input message is too long.
+- "encoding error": Raised when the input message fails encoding.
+- "invalid blind": Raised when the inverse of r cannot be found.
+
+Steps:
+1. msg_salt = random(32)
+2. salted_msg = msg_salt || msg
+3. blinded_msg, inv = blind(pkS, msg)
+4. output msg_salt, blinded_msg, inv
+~~~
+
+### Salted Finalize
+
+rsabssa_salted_finalize invokes rsabssa_finalize directly with the salted
+message and outputs the result.
+
+~~~
+rsabssa_salted_finalize(pkS, msg, blind_sig, inv)
+
+Parameters:
+- kLen, the length in octets of the RSA modulus n
+
+Inputs:
+- pkS, server public key (n, e)
+- msg, message to be signed, an octet string
+- msg_salt, the 32 octets random salt used to salt the message
+- blind_sig, signed and blinded element, an octet string of
+  length kLen
+- inv, inverse of the blind, an octet string of length kLen
+
+Outputs:
+- sig, an octet string of length kLen
+
+Errors:
+- "invalid signature": Raised when the signature is invalid
+- "unexpected input size": Raised when a byte string input doesn't
+  have the expected length.
+
+Steps:
+1. salted_msg = msg_salt || msg
+2. output rsabssa_finalize(pkS, salted_msg, blind_sig, inv)
+~~~
+
+### Salted Verify
+
+rsabssa_salted_verify validates the resulting unblinded signature computed over a
+salted message. It invokes RSASSA-PSS-VERIFY directly by augmenting the input
+message with the message salt.
+
+~~~
+rsabssa_salted_verify(pkS, msg, msg_salt, sig)
+
+Parameters:
+- kLen, the length in octets of the RSA modulus n
+
+Inputs:
+- pkS, server public key (n, e)
+- msg, message to be signed, an octet string
+- msg_salt, the 32 octets random salt used to salt the message
+- sig, signature of the salted_msg
+
+Outputs:
+- "valid signature" if the signature is valid
+
+Errors:
+- "invalid signature": Raised when the signature is invalid
+
+Steps:
+1. salted_msg = HF(salt_msg || msg )
+2. result = RSASSA-PSS-VERIFY(pkS, salted_msg, sig)
+3. If result = "valid signature", output "valid signature", else
+  raise "invalid signature" and stop
+~~~
+
 ## Encoding Options {#pss-options}
 
 The RSASSA-PSS parameters, defined as in {{!RFC8017, Section 9.1.1}}, are as follows:
@@ -346,13 +457,14 @@ The RSASSA-PSS parameters, defined as in {{!RFC8017, Section 9.1.1}}, are as fol
 - MGF: mask generation function
 - sLen: intended length in octets of the salt
 
-Implementations MUST support PS384-encoding, using SHA-384 as Hash and MGF functions
-and sLen = 48, as described in {{!RFC8230, Section 2}}. It is RECOMMENDED that
-implementations also support encoding using SHA-384 as Hash and MGF functions and
-sLen = 0. Note that setting sLen = 0 has the result of making the signature
-deterministic.
+It is RECOMMENDED that implementations support the following encoding options:
 
-The blinded functions in {{generation}} are orthogonal to the choice of these options.
+- SHA-384 as Hash and MGF functions and sLen = 48, as described in {{!RFC8230, Section 2}}; and
+- SHA-384 as Hash and MGF functions and sLen = 0.
+
+Note that setting sLen = 0 has the result of making the signature deterministic.
+
+The blinded functions in {{generation}} are orthogonal to the choice of these encoding options.
 
 # Public Key Certification {#cert-oid}
 

--- a/draft-irtf-cfrg-rsa-blind-signatures.md
+++ b/draft-irtf-cfrg-rsa-blind-signatures.md
@@ -466,7 +466,7 @@ Errors:
 - "invalid signature": Raised when the signature is invalid
 
 Steps:
-1. salted_msg = salt_msg || msg
+1. salted_msg = msg_salt || msg
 2. result = RSASSA-PSS-VERIFY(pkS, salted_msg, sig)
 3. If result = "valid signature", output "valid signature", else
   raise "invalid signature" and stop


### PR DESCRIPTION
Alternative to #105 that splits out the two interfaces. Based on this presentation, I think the key question we need to ask ourselves is: is deterministic signing with high-entropy inputs a use case we want to support? If not, we can just expose the "external" (salted) interfaces. Otherwise, we would need to support both, and give guidance as to when each should be used. (Hopefully this clarifies my comment in the other PR!)