### PR TITLE
Rephrase inverse_mod syntax

### DIFF
--- a/draft-irtf-cfrg-rsa-blind-signatures.md
+++ b/draft-irtf-cfrg-rsa-blind-signatures.md
@@ -172,8 +172,7 @@ in this document:
   in big-endian byte order.
 - random_integer_uniform(M, N): Generate a random, uniformly distributed integer R
   such that M <= R < N.
-- inverse_mod(x, n): Compute the multiplicative inverse of x mod n. This function
-  fails if x and n are not co-prime.
+- inverse_mod(x, n): Compute the multiplicative inverse of x mod n or fail if x and n are not co-prime.
 - len(s): The length of a byte string, in bytes.
 - random(n): Generate n random bytes using a cryptographically-secure pseudorandom number generator.
 


### PR DESCRIPTION
Closes #145 

I went with the approach that requires the function to fail if the inputs are not co-prime, since the protocol function definitions depend on that failure being produced to detect invalid blinds.