### PR TITLE
Add explicit Prepare step to motivate randomization

### DIFF
--- a/draft-irtf-cfrg-rsa-blind-signatures.md
+++ b/draft-irtf-cfrg-rsa-blind-signatures.md
@@ -455,7 +455,7 @@ variant, but only if their input messages have high entropy. Applications that u
 RSABSSA-SHA384-PSSZERO-Deterministic SHOULD carefully analyze the security implications,
 taking into account the possibility of adversarially generated signer keys as described in
 {{message-entropy}}. When it is not clear whether an application requires deterministic or
-randomized signatures, applications SHOULD use one of the recommended variants with randomized message preparation.
+randomized signatures, applications SHOULD use one of the variants with randomized message preparation.
 
 # Implementation and Usage Considerations
 

--- a/draft-irtf-cfrg-rsa-blind-signatures.md
+++ b/draft-irtf-cfrg-rsa-blind-signatures.md
@@ -198,17 +198,25 @@ in this document:
 # Blind Signature Protocol {#core-protocol}
 
 The core RSA Blind Signature Protocol is a two-party protocol between a client and server
-where they interact to compute `sig = Sign(skS, msg)`, where `msg` is the private message
-to be signed, and `skS` is the server's private key. In this protocol, the server
-learns nothing of `msg`, whereas the client learns `sig` and nothing of `skS`.
+where they interact to compute `sig = Sign(skS, input_msg)`, where `input_msg = Prepare(msg)`
+is a prepared version of the private message `msg`, and `skS` is the server's private key.
+In this protocol, the server learns nothing of `msg` or `input_msg`, whereas the client
+learns `sig` and nothing of `skS`.
 
-The protocol consists of three functions -- Blind, BlindSign, and Finalize -- and requires
-one round of interaction between client and server. Let `msg` be the private input message
-that the client wants to sign, and `(skS, pkS)` be the server's private and public key pair.
-The protocol begins by the client computing:
+The protocol consists of four functions -- Prepare, Blind, BlindSign, and Finalize -- and requires
+one round of interaction between client and server. Let `msg` be the client's private input
+message, and `(skS, pkS)` be the server's private and public key pair.
+
+The protocol begins by the client preparing the message to be signed by computing:
 
 ~~~
-blinded_msg, inv = Blind(pkS, msg)
+input_msg = Prepare(msg)
+~~~
+
+The client then initiates the blind signature protocol by computing:
+
+~~~
+blinded_msg, inv = Blind(pkS, input_msg)
 ~~~
 
 The client then sends `blinded_msg` to the server, which then processes the message
@@ -221,11 +229,11 @@ blind_sig = BlindSign(skS, blinded_msg)
 The server then sends `blind_sig` to the client, which the finalizes the protocol by computing:
 
 ~~~
-sig = Finalize(pkS, msg, blind_sig, inv)
+sig = Finalize(pkS, input_msg, blind_sig, inv)
 ~~~
 
-Upon completion, correctness requires that clients can verify signature `sig` over private
-input message `msg` using the server public key `pkS` by invoking the RSASSA-PSS-VERIFY
+Upon completion, correctness requires that clients can verify signature `sig` over
+the prepared message `input_msg` using the server public key `pkS` by invoking the RSASSA-PSS-VERIFY
 routine defined in {{Section 8.1.2 of !RFC8017}}. The Finalize function performs that
 check before returning the signature.
 
@@ -234,7 +242,8 @@ In pictures, the core protocol runs as follows:
 ~~~
    Client(pkS, msg)                      Server(skS, pkS)
   -------------------------------------------------------
-  blinded_msg, inv = Blind(pkS, msg)
+  input_msg = Prepare(msg)
+  blinded_msg, inv = Blind(pkS, input_msg)
 
                         blinded_msg
                         ---------->
@@ -244,11 +253,38 @@ In pictures, the core protocol runs as follows:
                          blind_sig
                         <----------
 
-  sig = Finalize(pkS, msg, blind_sig, inv)
+  sig = Finalize(pkS, input_msg, blind_sig, inv)
 ~~~
 
 In the remainder of this section, we specify Blind, BlindSign, and Finalize that are
 used in this protocol.
+
+## Prepare {#randomization}
+
+Message preparation, denoted by the Prepare function, is the process by which the message
+to be signed and verified is prepared for input to the blind signing protocol.
+There are two types of preparation functions: the identity preparation function,
+and a randomized preparation function. The identity preparation function returns
+the input message without transformation, i.e., `msg = Prepare(msg)`.
+
+The randomized preparation function augments the input message with fresh randomness.
+We denote this process by the function Randomize(msg), which takes as input a message
+`msg` and produces a randomized message `randomMsg`. Its implementation is shown below.
+
+~~~
+Randomize(msg)
+
+Inputs:
+- msg, message to be signed, a byte string
+
+Outputs:
+- randomMsg, a byte string that is 32 bytes longer than input msg
+
+Steps:
+1. msgPrefix = random(32)
+2. randomMsg = concat(msgPrefix, msg)
+3. output randomMsg
+~~~
 
 ## Blind {#blind}
 
@@ -375,59 +411,34 @@ Steps:
    raise "invalid signature" and stop
 ~~~
 
-# Message Randomization {#randomization}
-
-Message randomization is the process by which the message to be signed and verified
-is augmented with fresh randomness. As such, message randomization is a procedure
-invoked before the protocol in {{core-protocol}}, as it changes the contents of
-the message being signed. We denote this process by the function Randomize(msg),
-which takes as input a message `msg` and produces a randomized message `randomMsg`.
-Its implementation is shown below.
-
-~~~
-Randomize(msg)
-
-Inputs:
-- msg, message to be signed, a byte string
-
-Outputs:
-- randomMsg, a byte string that is 32 bytes longer than input msg
-
-Steps:
-1. msgPrefix = random(32)
-2. randomMsg = concat(msgPrefix, msg)
-3. output randomMsg
-~~~
-
 # RSABSSA Variants {#rsabssa}
 
 In this section we define different named variants of RSABSSA. Each variant specifies
 a hash function, RSASSA-PSS parameters as defined in {{Section 9.1.1 of !RFC8017}}, and
-whether or not message randomization (as described in {{randomization}}) is performed
-on the input message. Future specifications can introduce other variants as desired.
-The named variants are as follows:
+the type of message preparation function applied (as described in {{randomization}}).
+Future specifications can introduce other variants as desired. The named variants are as follows:
 
 1. RSABSSA-SHA384-PSS-Randomized: This named variant uses SHA-384 as the hash function,
 MGF1 with SHA-384 as the PSS mask generation function, a 48-byte salt length, and uses
-message randomization.
+the randomized preparation function (Randomize).
 
 1. RSABSSA-SHA384-PSSZERO-Randomized: This named variant uses SHA-384 as the hash function,
 MGF1 with SHA-384 as the PSS mask generation function, an empty PSS salt, and uses
-message randomization.
+the randomized preparation function (Randomize).
 
 1. RSABSSA-SHA384-PSS-Deterministic: This named variant uses SHA-384 as the hash function,
-MGF1 with SHA-384 as the PSS mask generation function, 48-byte salt length, and does not use
-message randomization.
+MGF1 with SHA-384 as the PSS mask generation function, 48-byte salt length, and uses
+the identity preparation function.
 
 1. RSABSSA-SHA384-PSSZERO-Deterministic: This named variant uses SHA-384 as the hash function,
-MGF1 with SHA-384 as the PSS mask generation function, an empty PSS salt, and does not use
-message randomization. This is the only variant that produces deterministic signatures over
-the input message.
+MGF1 with SHA-384 as the PSS mask generation function, an empty PSS salt, and uses
+the identity preparation function. This is the only variant that produces deterministic signatures
+over the client's input message `msg`.
 
 The RECOMMENDED variants are RSABSSA-SHA384-PSS-Randomized or RSABSSA-SHA384-PSSZERO-Randomized.
 
 Not all named variants can be used interchangeably. In particular, applications that provide
-high-entropy input messages can safely use named variants without message randomization, as
+high-entropy input messages can safely use named variants without randomized message preparation, as
 the additional message randomization does not offer security advantages. See {{Lys22}} and
 {{message-entropy}} for more information.
 
@@ -436,8 +447,7 @@ variant, but only if their input messages have high entropy. Applications that u
 RSABSSA-SHA384-PSSZERO-Deterministic SHOULD carefully analyze the security implications,
 taking into account the possibility of adversarially generated signer keys as described in
 {{message-entropy}}. When it is not clear whether an application requires deterministic or
-randomized signatures, applications SHOULD use one of the recommended variants with message
-randomization.
+randomized signatures, applications SHOULD use one of the recommended variants with randomized message preparation.
 
 # Implementation and Usage Considerations
 
@@ -537,7 +547,7 @@ unless one of the following conditions are met:
   public key.
 2. The client input message has high entropy.
 
-The named variants that use message randomization -- RSABSSA-SHA384-PSS-Randomized and
+The named variants that use the randomization preparation function -- RSABSSA-SHA384-PSS-Randomized and
 RSABSSA-SHA384-PSSZERO-Randomized -- explicitly inject fresh entropy alongside each message
 to satisfy condition (2). As such, these variants are safe for all application use cases.
 
@@ -647,9 +657,9 @@ The following parameters are specified for each test vector:
 - p, q, n, e, d: RSA private and public key parameters, each encoded as a hexadecimal string.
 - msg: Input messsage being signed, encoded as a hexadecimal string. The hash is computed using SHA-384.
 - msg\_prefix: Message randomizer prefix, encoded as a hexadecimal string. This is only present for variants
-  that use message randomization.
-- random\_msg: The message actually signed. If the variant does not use message randomization, this is equal
-  to msg.
+  that use the randomization preparation function.
+- random\_msg: The message actually signed. If the variant does not use the randomization preparation
+  function, this is equal to msg.
 - salt: Randomly-generated salt used when computing the signature. The length is either 48 or 0 bytes.
 - encoded\_msg: EMSA-PSS encoded message. The mask generation function is MGF1 with SHA-384.
 - inv: The message blinding inverse, encoded as a hexadecimal string.

--- a/draft-irtf-cfrg-rsa-blind-signatures.md
+++ b/draft-irtf-cfrg-rsa-blind-signatures.md
@@ -278,7 +278,7 @@ Inputs:
 - msg, message to be signed, a byte string
 
 Outputs:
-- randomMsg, a byte string that is 32 bytes longer than input msg
+- input_msg, a byte string that is 32 bytes longer than msg
 
 Steps:
 1. msgPrefix = random(32)

--- a/draft-irtf-cfrg-rsa-blind-signatures.md
+++ b/draft-irtf-cfrg-rsa-blind-signatures.md
@@ -282,8 +282,8 @@ Outputs:
 
 Steps:
 1. msgPrefix = random(32)
-2. randomMsg = concat(msgPrefix, msg)
-3. output randomMsg
+2. input_msg = concat(msgPrefix, msg)
+3. output input_msg
 ~~~
 
 ## Blind {#blind}


### PR DESCRIPTION
Closes #148

This adds an explicit `Prepare` step to the protocol, which is either a no-op (in the case of no randomization applied) or it augments the message with randomness. Rather than making the protocol description a complicated series of "if your application needs this, then first invoke the randomizer routine...." and so on, it seemed easier to just wrap up this step in a generic "preparation" function. The named variants then just say what the prepare step does, i.e., it either spits out the input message or one that has been augmented with randomness.

@martinthomson, @smhendrickson: does this seem more approachable to you?