### PR TITLE
Minor fix from Melinda's review

### DIFF
--- a/draft-irtf-cfrg-rsa-blind-signatures.md
+++ b/draft-irtf-cfrg-rsa-blind-signatures.md
@@ -327,7 +327,7 @@ Inputs:
 
 Outputs:
 - blinded_msg, a byte string of length kLen
-- inv, an integer
+- inv, an integer representing the inverse of r mod n
 
 Errors:
 - "message too long": Raised when the input message is too long (raised by EMSA-PSS-ENCODE).

--- a/draft-irtf-cfrg-rsa-blind-signatures.md
+++ b/draft-irtf-cfrg-rsa-blind-signatures.md
@@ -327,7 +327,7 @@ Inputs:
 
 Outputs:
 - blinded_msg, a byte string of length kLen
-- inv, an integer representing the inverse of r mod n
+- inv, an integer used to unblind the signature in Finalize
 
 Errors:
 - "message too long": Raised when the input message is too long (raised by EMSA-PSS-ENCODE).


### PR DESCRIPTION
From the review:
> The authors might want to throw a word or two into the beginning of
section 4 defining “inv” (the other inputs/outputs are defined there).
However, this is not strictly necessary given the summary nature of
its use in the first few paragraphs of section 4.